### PR TITLE
Qt 6.x compatibility fixes

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 include_directories(lexicon)
 
 qt_add_qml_module(libatproto
+    VERSION 5.12
     URI atproto.lib
     IMPORT_PATH .
     SOURCES

--- a/lib/plc_directory_client.cpp
+++ b/lib/plc_directory_client.cpp
@@ -16,7 +16,7 @@ static QString normalizeHost(const QString& host)
         normalized = "https://" + normalized;
 
     if (normalized.endsWith('/'))
-        normalized.slice(0, normalized.size() - 1);
+        normalized.chop(1);
 
     return normalized;
 }


### PR DESCRIPTION
Hope it's ok to submit a couple fixes for issues I ran into while building sKeets. I've patched it in my repo but as they're mainly compatibility it made sense to submit them. 

- VERSION is missing which was causing a configuration error, I set it to the latest version in the release notes but [the project version](https://github.com/mfnboer/atproto/blob/75480682acc652ca7af2d97bf2f4b4732c9a4558/CMakeLists.txt#L3) also needs to be updated.
- Switch to chop() instead of slice() for Qt 6.x